### PR TITLE
Resolve gcc compilation warnings

### DIFF
--- a/theft.c
+++ b/theft.c
@@ -91,7 +91,7 @@ static void infer_arity(struct theft_propfun_info *info) {
  * See the type definition in `theft_types.h`. */
 theft_run_res
 theft_run(struct theft *t, struct theft_cfg *cfg) {
-    if (t == NULL | cfg == NULL) {
+    if (t == NULL || cfg == NULL) {
         return THEFT_RUN_ERROR_BAD_ARGS;
     }
 

--- a/theft.c
+++ b/theft.c
@@ -480,7 +480,7 @@ static theft_progress_callback_res report_on_failure(theft *t,
     int arity = info->arity;
     fprintf(t->out, "\n\n -- Counter-Example: %s\n",
         info->name ? info-> name : "");
-    fprintf(t->out, "    Trial %u, Seed 0x%016llx\n", ti->trial,
+    fprintf(t->out, "    Trial %u, Seed 0x%016"PRIx64"\n", ti->trial,
         (uint64_t)ti->seed);
     for (int i = 0; i < arity; i++) {
         theft_print_cb *print = info->type_info[i]->print;

--- a/theft_types.h
+++ b/theft_types.h
@@ -1,6 +1,8 @@
 #ifndef THEFT_TYPES_H
 #define THEFT_TYPES_H
 
+#include "inttypes.h"
+
 /* A pseudo-random number/seed, used to generate instances. */
 typedef uint64_t theft_seed;
 


### PR DESCRIPTION
Went to use theft just now and saw some warnings that seem to have good reasoning, so I fixed them.

Not super familiar with C so I'm not sure if there's pitfalls around `PRId64` but everything I read suggests it's *intended* to be portable. I just know that gcc 4.9.1 has it. :)