### PR TITLE
A pkg-config file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,22 +97,28 @@ ${BUILD}/theft_autoshrink.o: ${BUILD}/bits_lut.h
 ${BUILD}/bits_lut.h: | ${BUILD}
 	${SCRIPTS}/mk_bits_lut > $@
 
+${BUILD}/%.pc: pc/%.pc.in | ${BUILD}
+	sed -e 's,@prefix@,${PREFIX},g' $< > $@
+
 # Installation
 PREFIX ?=	/usr/local
 INSTALL ?= 	install
 RM ?=		rm
 
-install: ${BUILD}/lib${PROJECT}.a
+install: ${BUILD}/lib${PROJECT}.a ${BUILD}/lib${PROJECT}.pc
 	${INSTALL} -d ${PREFIX}/lib/
 	${INSTALL} -c ${BUILD}/lib${PROJECT}.a ${PREFIX}/lib/lib${PROJECT}.a
 	${INSTALL} -d ${PREFIX}/include/
 	${INSTALL} -c ${INC}/${PROJECT}.h ${PREFIX}/include/
 	${INSTALL} -c ${INC}/${PROJECT}_types.h ${PREFIX}/include/
+	${INSTALL} -d ${PREFIX}/share/pkgconfig/
+	${INSTALL} -c ${BUILD}/lib${PROJECT}.pc ${PREFIX}/share/pkgconfig/
 
 uninstall:
 	${RM} ${PREFIX}/lib/lib${PROJECT}.a
 	${RM} ${PREFIX}/include/${PROJECT}.h
 	${RM} ${PREFIX}/include/${PROJECT}_types.h
+	${RM} ${PREFIX}/share/pkgconfig/lib${PROJECT}.pc
 
 
 # Other dependencies

--- a/pc/libtheft.pc.in
+++ b/pc/libtheft.pc.in
@@ -1,0 +1,13 @@
+prefix=@prefix@
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: libtheft
+Description: Theft
+Version: 0.4.3
+Requires:
+Requires.private:
+Libs: -L${libdir} -ltheft
+Libs.private: -lm
+Cflags: -I${includedir}
+


### PR DESCRIPTION
I'm not sure if you want to provide this, or leave it to a package manager. But here you are, in any case.

Using it looks like pkg-config per usual:
```
; pkg-config --cflags --libs libtheft
-I/tmp/prefix/include -L/tmp/prefix/lib -ltheft
```