### PR TITLE
Fix bug in hexdump for printing char array counter-examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ TEST_OBJS=	${BUILD}/test_theft.o \
 		${BUILD}/test_theft_error.o \
 		${BUILD}/test_theft_prng.o \
 		${BUILD}/test_theft_integration.o \
+	   ${BUILD}/test_char_array.o \
 
 
 # Basic targets

--- a/src/theft_aux_builtin.c
+++ b/src/theft_aux_builtin.c
@@ -257,10 +257,9 @@ static void hexdump(FILE *f, const uint8_t *raw, size_t size) {
             fprintf(f, "%02x ", raw[row_i + i]);
         }
 
-        while (rem < 16) {      /* add padding */
-            fprintf(f, "   ");
-            rem++;
-        }
+        for (size_t ii = rem; ii < 16; ++ii)
+            fprintf(f, "   ");  /* add padding */
+
         for (size_t i = 0; i < rem; i++) {
             char c = ((const char *)raw)[i];
             fprintf(f, "%c", (isprint(c) ? c : '.'));

--- a/test/test_char_array.c
+++ b/test/test_char_array.c
@@ -1,0 +1,34 @@
+#include "test_theft.h"
+
+static enum theft_trial_res
+prop_char_fails_cause_shrink(struct theft *t, void *arg1) {
+    (void)t;
+    char *test_str = arg1;
+
+    return strlen(test_str) ? THEFT_TRIAL_FAIL : THEFT_TRIAL_PASS;
+}
+
+
+TEST char_fail_shrinkage(void) {
+    theft_seed seed = theft_seed_of_time();
+
+    struct theft_run_config cfg = {
+        .name = __func__,
+        .prop1 = prop_char_fails_cause_shrink,
+        .type_info = {
+            theft_get_builtin_type_info(THEFT_BUILTIN_char_ARRAY),
+        },
+        .bloom_bits = 20,
+        .seed = seed,
+        .trials = 1,
+    };
+
+    ASSERT_EQm("should fail until full contraction",
+               THEFT_RUN_FAIL, theft_run(&cfg));
+    PASS();
+}
+
+
+SUITE(char_array) {
+    RUN_TEST(char_fail_shrinkage);
+}

--- a/test/test_theft.c
+++ b/test/test_theft.c
@@ -45,5 +45,6 @@ int main(int argc, char **argv) {
     RUN_SUITE(error);
     RUN_SUITE(integration);
     RUN_SUITE(prng);
+    RUN_SUITE(char_array);
     GREATEST_MAIN_END();        /* display results */
 }

--- a/test/test_theft.h
+++ b/test/test_theft.h
@@ -18,5 +18,6 @@ SUITE_EXTERN(aux);
 SUITE_EXTERN(bloom);
 SUITE_EXTERN(error);
 SUITE_EXTERN(integration);
+SUITE_EXTERN(char_array);
 
 #endif


### PR DESCRIPTION
The `hexdump` function which is used to print char_array counter-examples modifies the `rem` variable (which represents the remaining amount to print for this row) to add padding, but then attempts to use `rem` as an end-marker for printing the actual characters themselves.  This will result in a buffer overflow error.  I added `test_char_array` and this effect can be observed by running `$ valgrind build/test_theft -s char_array`.  

The patch fixes `hexdump` to leave `rem` unchanged and therefore terminate the print loop at a valid location; `valgrind` is now happy.