### PR TITLE
theft_shrink: include theft_shrink.h for theft_shrink() declaration

### DIFF
--- a/src/theft_shrink.c
+++ b/src/theft_shrink.c
@@ -1,4 +1,5 @@
 #include "theft_shrink_internal.h"
+#include "theft_shrink.h"
 
 #include "theft_call.h"
 #include "theft_trial.h"


### PR DESCRIPTION
Otherwise, the compiler will not check the declaration in theft_shrink.h
against the definition in theft_shrink.c.

Enabling `-Wmissing-prototypes` emits a diagnostic in this case (may want
to enable it).