### PR TITLE
test/test_theft_error: check, don't assign in assert()

### DIFF
--- a/test/test_theft_error.c
+++ b/test/test_theft_error.c
@@ -25,7 +25,7 @@ static enum theft_alloc_res
 bits_alloc(struct theft *t, void *penv, void **output) {
     assert(penv);
     struct err_env *env = (struct err_env *)penv;
-    assert(env->tag = 'e');
+    assert(env->tag == 'e');
 
     if (env->b == BEH_SKIP_ALL) {
         return THEFT_ALLOC_SKIP;


### PR DESCRIPTION
Pretty sure this was meant to be a check.

Using `-Wparentheses` (included in `-Wall`) emits a diagnostic for this.