### PR TITLE
test/test_theft_integration: mark internal function as static

### DIFF
--- a/test/test_theft_integration.c
+++ b/test/test_theft_integration.c
@@ -1331,6 +1331,7 @@ struct verbose_test_env {
 };
 
 /* Re-run each failure once, with the verbose flag set. */
+static
 enum theft_hook_trial_post_res
 trial_post_repeat_with_verbose_set(const struct theft_hook_trial_post_info *info,
     void *env) {


### PR DESCRIPTION
trial_post_repeat_with_verbose_set() is local to this translation unit,
and lacks any seperate prototype. Mark it as static to keep it local.

Enabling `-Wmissing-prototypes' complains about issues like this one.