### PR TITLE
Fix UBSan error: Shifting 64 bit type by 64 is undefined behaviour

### DIFF
--- a/src/theft_random.c
+++ b/src/theft_random.c
@@ -76,7 +76,9 @@ void theft_random_bits_bulk(struct theft *t, uint32_t bit_count, uint64_t *buf) 
         LOG(5, "== buf[%zd]: %016" PRIx64 " (%u / %u)\n",
             offset, buf[offset], bit_count - rem, bit_count);
         t->prng.bits_available -= take;
-        t->prng.buf >>= take;
+
+        if(take < 64)
+                t->prng.buf >>= take;
 
         shift += take;
         if (shift == 64) {


### PR DESCRIPTION
Shifting a type by `>=sizeof(type)*8` is undefined behaviour in C. Since
`t->prng.buf` is overwritten on the next iteration anyways this thankfully
isn't a real bug here.

Fixes #52