### PR TITLE
build: add Meson buildsystem

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,93 @@
+project('theft', 'c',
+  version : '0.4.6',
+  default_options : [
+    'c_std=c99',
+    'warning_level=3',
+    'optimization=3',
+    'b_pgo=off',
+    'b_coverage=false',
+    'b_pie=true'
+  ]
+)
+
+c_args = [
+  '-D_POSIX_C_SOURCE=199309L',
+  '-D_C99_SOURCE',
+  '-pedantic'
+]
+
+inc_dirs = include_directories('inc', 'vendor')
+
+theft_sources = [
+  'src/theft.c',
+  'src/theft_autoshrink.c',
+  'src/theft_bloom.c',
+  'src/theft_call.c',
+  'src/theft_hash.c',
+  'src/theft_random.c',
+  'src/theft_rng.c',
+  'src/theft_run.c',
+  'src/theft_shrink.c',
+  'src/theft_trial.c',
+  'src/theft_aux.c',
+  'src/theft_aux_builtin.c'
+]
+
+test_sources = [
+  'test/test_theft.c',
+  'test/test_theft_autoshrink.c',
+  'test/test_theft_autoshrink_ll.c',
+  'test/test_theft_autoshrink_bulk.c',
+  'test/test_theft_autoshrink_int_array.c',
+  'test/test_theft_aux.c',
+  'test/test_theft_bloom.c',
+  'test/test_theft_error.c',
+  'test/test_theft_prng.c',
+  'test/test_theft_integration.c',
+  'test/test_char_array.c'
+]
+
+cc = meson.get_compiler('c')
+
+# m-library dependency handling
+mdep = cc.find_library('m', required: false)
+
+# Generate bits_lut.h
+bits_lut_gen = custom_target('bits_lut',
+  output : 'bits_lut.h',
+  command : ['scripts/mk_bits_lut'],
+  capture : true
+)
+
+theft_lib = library('theft',
+  theft_sources,
+  dependencies : mdep,
+  include_directories : inc_dirs,
+  c_args : c_args,
+  install : true
+)
+
+theft_dep = declare_dependency(
+    link_with : theft_lib,
+    dependencies : mdep,
+    include_directories : include_directories('inc'),
+)
+
+test_exe = executable('test_theft',
+  test_sources,
+  link_with : theft_lib,
+  include_directories : [inc_dirs, include_directories('src')],
+  c_args : c_args,
+  dependencies : mdep
+)
+
+install_headers('inc/theft.h', 'inc/theft_types.h')
+
+pkg = import('pkgconfig')
+pkg.generate(
+  name : 'theft',
+  description : 'Property-based testing for C',
+  libraries : theft_lib
+)
+
+test('theft tests', test_exe)


### PR DESCRIPTION
Decided to address https://github.com/silentbicycle/theft/issues/60 since the Makefile is very simple and easy to "translate".

This is how the process looks like:
```
theft on  meson                                                                                                                                                                                            19:55:32
$ meson setup build
The Meson build system
Version: 1.7.0
Source dir: /Users/xvilka/rizin/theft
Build dir: /Users/xvilka/rizin/theft/build
Build type: native build
Project name: theft
Project version: 0.4.6
C compiler for the host machine: cc (clang 16.0.0 "Apple clang version 16.0.0 (clang-1600.0.26.6)")
C linker for the host machine: cc ld64 1115.7.3
Host machine cpu family: aarch64
Host machine cpu: aarch64
Library m found: YES
Found pkg-config: YES (/opt/homebrew/bin/pkg-config) 2.4.3
Build targets in project: 3

Found ninja-1.12.1 at /opt/homebrew/bin/ninja
theft on  meson                                                                                                                                                                                            19:55:37

$ meson compile -C build
INFO: autodetecting backend as ninja
INFO: calculating backend command to run: /opt/homebrew/bin/ninja -C /Users/xvilka/rizin/theft/build
ninja: Entering directory `/Users/xvilka/rizin/theft/build'
[26/26] Linking target test_theft
theft on  meson                                                                                                                                                                                            19:55:42

$ meson test -C build
ninja: Entering directory `/Users/xvilka/rizin/theft/build'
ninja: no work to do.
1/1 theft tests        OK             24.76s

Ok:                 1
Expected Fail:      0
Fail:               0
Unexpected Pass:    0
Skipped:            0
Timeout:            0

Full log written to /Users/xvilka/rizin/theft/build/meson-logs/testlog.txt
```
Tried also with Muon and it builds just fine: https://github.com/rizinorg/rizin/actions/runs/13818011053/job/38656707916

This change also allows using Theft as Meson dependency. Just create `subprojects/theft.wrap` with following contents:
```
[wrap-git]
url = https://github.com/notxvilka/theft.git
revision = meson
depth = 1
```
(repository path and revision could be changed if this get merged)
and then add a dependency in any Meson project:
```meson
theft_proj = subproject('theft', default_options: [])
theft_dep = theft_proj.get_variable('theft_dep')
```
